### PR TITLE
refactor(optimize runner image): reduce image size to 133mb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,22 @@
-ARG VERSION=latest
-ARG OS=debian
-ARG CLI_NAME=atmos
-
-FROM cloudposse/geodesic:$VERSION-$OS
+# syntax=docker/dockerfile:1
+FROM alpine:3.19 as deps
 
 # Install terraform
-ARG TF_1_VERSION=1.2.3
-RUN apt-get update && \
-    apt-get install -y -u --allow-downgrades terraform-1="${TF_1_VERSION}-*"
+ARG TF_1_VERSION=1.5.7 # last release under Mozilla Public License
+ARG ALPINE_VERSION=1.52.0
+ARG TARGETARCH
 
-# Set Terraform 1.x as the default `terraform` in this container.
-# Other versions of TF can be installed + used via Spacelift before_init scripts.
-RUN update-alternatives --set terraform /usr/share/terraform/1/bin/terraform
+RUN apk add --no-cache wget unzip; \
+    wget -q "https://releases.hashicorp.com/terraform/${TF_1_VERSION}/terraform_${TF_1_VERSION}_linux_${TARGETARCH}.zip"; \
+    wget -q -O atmos "https://github.com/cloudposse/atmos/releases/download/v1.52.0/atmos_1.52.0_linux_${TARGETARCH}"; \
+    unzip "terraform_${TF_1_VERSION}_linux_${TARGETARCH}.zip"
 
-# Install Atmos
-RUN apt-get install -y --allow-downgrades atmos
+FROM alpine:3.19 as runner
 
-# Shell banner
-ENV BANNER="Atmos"
+RUN apk add --no-cache bash=5.2.21-r0 git=2.43.0-r0 openssh=9.6_p1-r0 jq=1.7.1-r0
 
-# Set SHELL for `atmos terraform shell`
-ENV SHELL=/bin/bash
-
-ENV DOCKER_IMAGE="spacelift-atmos-runner"
-ENV DOCKER_TAG="latest"
+COPY --from=deps --link terraform /usr/local/bin/terraform
+COPY --from=deps --link atmos /usr/local/bin/atmos
 
 COPY rootfs/ /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,12 @@ FROM alpine:3.19 as deps
 
 # Install terraform
 ARG TF_1_VERSION=1.5.7 # last release under Mozilla Public License
-ARG ALPINE_VERSION=1.52.0
+ARG ATMOS_VERSION=1.52.0
 ARG TARGETARCH
 
 RUN apk add --no-cache wget unzip; \
     wget -q "https://releases.hashicorp.com/terraform/${TF_1_VERSION}/terraform_${TF_1_VERSION}_linux_${TARGETARCH}.zip"; \
-    wget -q -O atmos "https://github.com/cloudposse/atmos/releases/download/v1.52.0/atmos_1.52.0_linux_${TARGETARCH}"; \
+    wget -q -O atmos "https://github.com/cloudposse/atmos/releases/download/v${ATMOS_VERSION}/atmos_${ATMOS_VERSION}_linux_${TARGETARCH}"; \
     unzip "terraform_${TF_1_VERSION}_linux_${TARGETARCH}.zip"
 
 FROM alpine:3.19 as runner


### PR DESCRIPTION
previous images come in at 2.98gb after built on my local and take ~60seconds to build

new image shows 133mb on my local and takes 9s to build, a 95.5% reduction in size 😁 

NOTE: we don't build these images in CI and we mostly use `arm64` locally. When building for push to ECR make sure to specify `docker build --platform linux/amd64 ...`